### PR TITLE
Follow renames

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,9 +14,7 @@
         },
         {
             "taskName": "test",
-            "args": [
-                "${workspaceRoot}/tests/gitnstats.tests/gitnstats.tests.csproj"
-            ],
+            "args": [],
             "isTestCommand": true
         }
     ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.1.0.{build}
+version: 2.1.1.{build}
 pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2017

--- a/src/gitnstats.core/Analysis.cs
+++ b/src/gitnstats.core/Analysis.cs
@@ -12,16 +12,11 @@ namespace GitNStats.Core
         public static IEnumerable<PathCount> CountFileChanges(IEnumerable<(Commit, TreeEntryChanges)> diffs)
         {
             return diffs.Aggregate<(Commit Commit, TreeEntryChanges Diff), Dictionary<string, int>>(
-                new Dictionary<string, int>(),
+                new Dictionary<string, int>(), //filename, count
                 (acc, x) => {
-                    int newCount;
-                    if (x.Diff.Status == ChangeKind.Renamed) {
-                        newCount = acc.GetOrDefault(x.Diff.OldPath, 0) + 1;
-                    } else {
-                        newCount = acc.GetOrDefault(x.Diff.Path, 0) + 1;
-                    }
-
-                    acc[x.Diff.Path] = newCount;
+                    /* OldPath == NewPath when file was created or removed,
+                        so this it's okay to just always use OldPath */
+                    acc[x.Diff.Path] = acc.GetOrDefault(x.Diff.OldPath, 0) + 1;
 
                     if (x.Diff.Status == ChangeKind.Renamed) {
                         acc.Remove(x.Diff.OldPath);

--- a/src/gitnstats.core/Analysis.cs
+++ b/src/gitnstats.core/Analysis.cs
@@ -14,12 +14,15 @@ namespace GitNStats.Core
             return diffs.Aggregate<(Commit Commit, TreeEntryChanges Diff), Dictionary<string, int>>(
                 new Dictionary<string, int>(),
                 (acc, x) => {
+                    int newCount;
                     if (x.Diff.Status == ChangeKind.Renamed) {
-                        acc[x.Diff.Path] = acc[x.Diff.OldPath] + 1;
+                        newCount = acc[x.Diff.OldPath] + 1;
                         acc.Remove(x.Diff.OldPath);
                     } else {
-                        acc[x.Diff.Path] = acc.GetOrDefault(x.Diff.Path, 0) + 1;
+                        newCount = acc.GetOrDefault(x.Diff.Path, 0) + 1;
                     }
+
+                    acc[x.Diff.Path] = newCount;
                     return acc;
                 }
             )

--- a/src/gitnstats.core/Analysis.cs
+++ b/src/gitnstats.core/Analysis.cs
@@ -16,7 +16,7 @@ namespace GitNStats.Core
                 (acc, x) => {
                     int newCount;
                     if (x.Diff.Status == ChangeKind.Renamed) {
-                        newCount = acc[x.Diff.OldPath] + 1;
+                        newCount = acc.GetOrDefault(x.Diff.OldPath, 0) + 1;
                     } else {
                         newCount = acc.GetOrDefault(x.Diff.Path, 0) + 1;
                     }

--- a/src/gitnstats.core/Analysis.cs
+++ b/src/gitnstats.core/Analysis.cs
@@ -11,10 +11,35 @@ namespace GitNStats.Core
     {
         public static IEnumerable<PathCount> CountFileChanges(IEnumerable<(Commit, TreeEntryChanges)> diffs)
         {
-            return diffs
-                .GroupBy<(Commit Commit, TreeEntryChanges Diff), string>(c => c.Diff.Path)
-                .Select(x => new PathCount(x.Key, x.Count()))
-                .OrderByDescending(s => s.Count);
+            // public static TResult Aggregate<TSource,TAccumulate,TResult> 
+            // (this System.Collections.Generic.IEnumerable<TSource> source, 
+            // TAccumulate seed, 
+            // Func<TAccumulate,TSource,TAccumulate> func, 
+            // Func<TAccumulate,TResult> resultSelector);
+
+            return diffs.Aggregate<(Commit Commit, TreeEntryChanges Diff), Dictionary<string, int>>(
+                new Dictionary<string, int>(),
+                (acc, x) => {
+                    if (x.Diff.Status == ChangeKind.Renamed) {
+                        var oldCount = acc[x.Diff.OldPath];
+                        acc.Remove(x.Diff.OldPath);
+                        acc[x.Diff.Path] = oldCount + 1;
+                    } else {
+                        if (acc.TryGetValue(x.Diff.Path, out int count)) {
+                            acc[x.Diff.Path] = count + 1;
+                        } else {
+                            acc[x.Diff.Path] = 1;
+                        }
+                    }
+                    return acc;
+                }
+            ).Select(x => new PathCount(x.Key, x.Value))
+            .OrderByDescending(s => s.Count);
+
+            // return diffs
+            //     .GroupBy<(Commit Commit, TreeEntryChanges Diff), string>(c => c.Diff.Path)
+            //     .Select(x => new PathCount(x.Key, x.Count()))
+            //     .OrderByDescending(s => s.Count);
         }
 
         /// <summary>

--- a/src/gitnstats.core/Analysis.cs
+++ b/src/gitnstats.core/Analysis.cs
@@ -17,12 +17,16 @@ namespace GitNStats.Core
                     int newCount;
                     if (x.Diff.Status == ChangeKind.Renamed) {
                         newCount = acc[x.Diff.OldPath] + 1;
-                        acc.Remove(x.Diff.OldPath);
                     } else {
                         newCount = acc.GetOrDefault(x.Diff.Path, 0) + 1;
                     }
 
                     acc[x.Diff.Path] = newCount;
+
+                    if (x.Diff.Status == ChangeKind.Renamed) {
+                        acc.Remove(x.Diff.OldPath);
+                    }
+
                     return acc;
                 }
             )

--- a/src/gitnstats/gitnstats.csproj
+++ b/src/gitnstats/gitnstats.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <RootNamespace>GitNStats</RootNamespace>
     <RuntimeIdentifiers>
       <RuntimeIdentifier>osx.10.12-x64</RuntimeIdentifier>

--- a/tests/gitnstats.core.tests/Analysis/CountFileChangesSpec.cs
+++ b/tests/gitnstats.core.tests/Analysis/CountFileChangesSpec.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using GitNStats.Core.Tests;
+using LibGit2Sharp;
+using Xunit;
+using Moq;
+
+using static GitNStats.Core.Analysis;
+using static GitNStats.Core.Tests.Fakes;
+
+namespace GitNStats.Tests.Analysis
+{
+    public class CountFileChangesSpec
+    {   
+        [Fact]
+        public void OneEntryIsCounted()
+        {
+            var diffs = new List<(Commit, TreeEntryChanges)>()
+            {
+                (Fakes.Commit().Object, Fakes.TreeEntryChanges("path/to/file").Object),
+            };
+            
+            Assert.Equal(1, CountFileChanges(diffs).Single().Count);
+        }
+        
+        [Fact]
+        public void TwoEntriesForSameFileAreCounted()
+        {
+            var diffs = new List<(Commit, TreeEntryChanges)>()
+            {
+                (Fakes.Commit().Object, Fakes.TreeEntryChanges("path/to/file").Object),
+                (Fakes.Commit().Object, Fakes.TreeEntryChanges("path/to/file").Object),
+            };
+            
+            Assert.Equal(2, CountFileChanges(diffs).Single().Count);
+        }
+
+        [Fact]
+        public void TwoEntriesForTwoDifferentFilesAreCountedSeparately()
+        {
+            var diffs = new List<(Commit, TreeEntryChanges)>()
+            {
+                (Fakes.Commit().Object, Fakes.TreeEntryChanges("path/to/fileA").Object),
+                (Fakes.Commit().Object, Fakes.TreeEntryChanges("path/to/fileB").Object),
+                (Fakes.Commit().Object, Fakes.TreeEntryChanges("path/to/fileB").Object),
+            };
+            
+            Assert.Equal(1, CountFileChanges(diffs).Single(d => d.Path == "path/to/fileA").Count);
+            Assert.Equal(2, CountFileChanges(diffs).Single(d => d.Path == "path/to/fileB").Count);
+        }
+
+        [Fact]
+        public void RenamedFileHasHistory()
+        {
+            var fileA = Fakes.TreeEntryChanges("fileA");
+            var fileB = Fakes.TreeEntryChanges("fileB");
+            fileB.SetupGet(d => d.Status).Returns(ChangeKind.Renamed);
+            fileB.SetupGet(d => d.OldPath).Returns(fileA.Object.Path);
+
+            var diffs = new List<(Commit, TreeEntryChanges)>()
+            {
+                (Fakes.Commit().Object, fileA.Object),
+                (Fakes.Commit().Object, fileB.Object)
+            };
+
+            var pathCounts = CountFileChanges(diffs);
+            Assert.Equal("fileB", pathCounts.Single().Path);
+            Assert.Equal(2, pathCounts.Single().Count);
+        }
+    }
+}

--- a/tests/gitnstats.core.tests/Fakes.cs
+++ b/tests/gitnstats.core.tests/Fakes.cs
@@ -56,7 +56,8 @@ namespace GitNStats.Core.Tests
         {
             var treeChanges = new Mock<TreeEntryChanges>();
             treeChanges.Setup(t => t.Path).Returns(filePath);
-
+            treeChanges.Setup(t => t.Status).Returns(ChangeKind.Modified);
+            
             return treeChanges;
         }
         

--- a/tests/gitnstats.core.tests/Fakes.cs
+++ b/tests/gitnstats.core.tests/Fakes.cs
@@ -56,6 +56,7 @@ namespace GitNStats.Core.Tests
         {
             var treeChanges = new Mock<TreeEntryChanges>();
             treeChanges.Setup(t => t.Path).Returns(filePath);
+            treeChanges.Setup(t => t.OldPath).Returns(filePath);
             treeChanges.Setup(t => t.Status).Returns(ChangeKind.Modified);
             
             return treeChanges;


### PR DESCRIPTION
Closes #2.

Output diff v2.1.0 vs v2.1.1
Note that files like `CommitVisitor.cs` are now properly aggregating their counts, even after a rename or move.

```diff
2c2
< Branch: master
---
> Branch: follow-renames
7a8
> 11	src/gitnstats.core/CommitVisitor.cs
8a10,11
> 9	src/gitnstats.core/DiffListener.cs
> 8	tests/gitnstats.core.tests/gitnstats.core.tests.csproj
9a13
> 7	tests/gitnstats.core.tests/Visitor/Walk.cs
12c16,17
< 6	src/gitnstats.core/CommitVisitor.cs
---
> 7	tests/gitnstats.core.tests/DiffListenerTests.cs
> 6	tests/gitnstats.core.tests/Fakes.cs
15,17c20
< 5	tests/gitnstats.tests/Visitor/Walk.cs
< 5	src/gitnstats/CommitVisitor.cs
< 5	src/gitnstats/DiffListener.cs
---
> 5	src/gitnstats.core/Analysis.cs
19a23
> 4	tests/gitnstats.tests/UnitTest1.cs
21,24c25,27
< 4	tests/gitnstats.tests/gitnstats.tests.csproj
< 4	tests/gitnstats.tests/Fakes.cs
< 4	tests/gitnstats.tests/DiffListenerTests.cs
< 4	src/gitnstats.core/DiffListener.cs
---
> 4	src/gitnstats.core/Visitor.cs
> 4	src/ubuntu16.dockerfile
> 4	src/gitnstats.core/DiffCollector.cs
26,27d28
< 3	src/gitnstats/Visitor.cs
< 3	src/ubuntu16.dockerfile
29,32c30,32
< 3	tests/gitnstats.core.tests/gitnstats.core.tests.csproj
< 3	tests/gitnstats.core.tests/DiffListenerTests.cs
< 3	src/gitnstats.core/DiffCollector.cs
< 3	src/gitnstats.core/Analysis.cs
---
> 3	tests/gitnstats.core.tests/DiffCollectorTests.cs
> 3	src/gitnstats.core/PathCount.cs
> 3	tests/gitnstats.core.tests/Analysis/DateFilter.cs
35,36d34
< 2	tests/UnitTest1.cs
< 2	tests/gitnstats.tests/UnitTest1.cs
39,40c37
< 2	src/gitnstats/PathCount.cs
< 2	src/gitnstats/Analysis.cs
---
> 2	src/gitnstats.core/Listener.cs
42,45d38
< 2	tests/gitnstats.core.tests/Visitor/Walk.cs
< 2	tests/gitnstats.core.tests/Fakes.cs
< 2	tests/gitnstats.core.tests/DiffCollectorTests.cs
< 2	tests/gitnstats.core.tests/Analysis/DateFilter.cs
51d43
< 1	tests/tests.csproj
56d47
< 1	src/gitnstats/Listener.cs
58,64d48
< 1	src/Dockerfile
< 1	tests/gitnstats.tests/DiffCollectorTests.cs
< 1	src/gitnstats/DiffCollector.cs
< 1	tests/gitnstats.tests/Analysis/DateFilter.cs
< 1	src/gitnstats.core/Visitor.cs
< 1	src/gitnstats.core/PathCount.cs
< 1	src/gitnstats.core/Listener.cs
``` 