### PR TITLE
Migration to .NET Core 3.1

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-framework=netcoreapp1.1
+framework=netcoreapp3.1
 bin=src/gitnstats/bin/Release
 
 echo "Cleaning ${bin}"
 rm -rf ${bin}/**
 
 # build the list of runtimes by parsing the *.csproj for runtime identifiers
-runtimes=($(grep '<RuntimeIdentifier>' src/gitnstats/gitnstats.csproj | sed -e 's,.*<RuntimeIdentifier>\([^<]*\)</RuntimeIdentifier>.*,\1,g'))
+IFS=';' read -ra runtimes <<< "$(grep '<RuntimeIdentifiers>' src/gitnstats/gitnstats.csproj | sed -e 's,.*<RuntimeIdentifiers>\([^<]*\)</RuntimeIdentifiers>.*,\1,g')"
 
 for runtime in ${runtimes[@]}; do
     echo "Restoring ${runtime}"

--- a/src/gitnstats.core/gitnstats.core.csproj
+++ b/src/gitnstats.core/gitnstats.core.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/gitnstats/gitnstats.csproj
+++ b/src/gitnstats/gitnstats.csproj
@@ -1,27 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-    <Version>2.1.1</Version>
-    <RootNamespace>GitNStats</RootNamespace>
-    <RuntimeIdentifiers>
-      <RuntimeIdentifier>osx.10.12-x64</RuntimeIdentifier>
-      <RuntimeIdentifier>ubuntu.14.04-x64</RuntimeIdentifier>
-      <RuntimeIdentifier>ubuntu.16.04-x64</RuntimeIdentifier>
-      <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
-    </RuntimeIdentifiers>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Version>2.2.0</Version>    
+    <RuntimeIdentifiers>osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;win10-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
-    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\gitnstats.core\gitnstats.core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\README.md" CopyToPublishDirectory="Always" />
     <Content Include="..\..\LICENSE.txt" CopyToPublishDirectory="Always" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\gitnstats.core\gitnstats.core.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <Authors>Christopher J. McClellan</Authors>

--- a/tests/gitnstats.core.tests/gitnstats.core.tests.csproj
+++ b/tests/gitnstats.core.tests/gitnstats.core.tests.csproj
@@ -1,15 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RootNamespace>GitNStats.Core.Tests</RootNamespace>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="moq" Version="4.7.63" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\gitnstats.core\gitnstats.core.csproj" />

--- a/tests/gitnstats.test/gitnstats.test.csproj
+++ b/tests/gitnstats.test/gitnstats.test.csproj
@@ -1,13 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.2.1" />
-    <PackageReference Include="moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\gitnstats\gitnstats.csproj" />


### PR DESCRIPTION
Migrating all projects to the last .NET Core LTS version (3.1). This fixes #14.