### PR TITLE
No longer publishes for specific OS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ Symoblic linking to a location already on the PATH (like `/usr/local/bin/`) is r
 ```bash
 # Download release (replace version and runtime accordingly)
 cd ~/Downloads
-wget https://github.com/rubberduck203/GitNStats/releases/download/2.2.0/osx.10.12-x64.zip
+wget https://github.com/rubberduck203/GitNStats/releases/download/2.3.0/osx-x64.zip
 
 # Create directory to keep package
 mkdir -p ~/bin/gitnstats
 
 # unzip
-unzip osx.10.12-x64.zip -d ~/bin/gitnstats
+unzip osx-x64.zip -d ~/bin/gitnstats
 
 # Create symlink
 ln -s /Users/rubberduck/bin/gitnstats/gitnstats /usr/local/bin/gitnstats

--- a/src/gitnstats/gitnstats.csproj
+++ b/src/gitnstats/gitnstats.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <Version>2.3.0</Version>
     <PublishTrimmed>true</PublishTrimmed>
-    <RuntimeIdentifiers>osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;win10-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx-x64;linux-x64;win10-x64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/ubuntu14.dockerfile
+++ b/src/ubuntu14.dockerfile
@@ -21,5 +21,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
  WORKDIR /root/
  RUN git clone https://github.com/rubberduck203/GitNStats
- COPY gitnstats/bin/Release/net5.0/ubuntu.14.04-x64/publish/ /root/bin/
+ COPY gitnstats/bin/release/net5.0/linux-x64/publish/ /root/bin/
  CMD bin/gitnstats GitNStats/

--- a/src/ubuntu16.dockerfile
+++ b/src/ubuntu16.dockerfile
@@ -21,6 +21,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
  WORKDIR /root/
  RUN git clone https://github.com/rubberduck203/GitNStats
- COPY gitnstats/bin/Release/net5.0/ubuntu.16.04-x64/publish/ /root/bin/
+ COPY gitnstats/bin/release/net5.0/linux-x64/publish/ /root/bin/
  CMD bin/gitnstats GitNStats/
     


### PR DESCRIPTION
Now we publish for Win10, OSX, and Linux, instead of specific versions of Ubuntu (which were quite outdated) and Mac.