### PR TITLE
Fixes #27: Disable nullable reference types for options class

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Symoblic linking to a location already on the PATH (like `/usr/local/bin/`) is r
 ```bash
 # Download release (replace version and runtime accordingly)
 cd ~/Downloads
-wget https://github.com/rubberduck203/GitNStats/releases/download/2.3.0/osx-x64.zip
+wget https://github.com/rubberduck203/GitNStats/releases/download/2.3.1/osx-x64.zip
 
 # Create directory to keep package
 mkdir -p ~/bin/gitnstats

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.0.{build}
+version: 2.3.1.{build}
 pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2019 Preview

--- a/src/gitnstats/Options.cs
+++ b/src/gitnstats/Options.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// re-enable when https://github.com/commandlineparser/commandline/pull/715 is merged & released
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using CommandLine;
 using CommandLine.Text;
@@ -10,10 +13,10 @@ namespace GitNStats
         private const string RepoPathHelpText = "Path to the git repository to be analyzed. Defaults to the current working directory.";
         
         [Value(1, HelpText = RepoPathHelpText, MetaName = "FilePath")]
-        public string? RepositoryPath { get; set; }
+        public string RepositoryPath { get; set; }
         
         [Option('b', "branch", HelpText = "Defaults to the currently active branch.")]
-        public string? BranchName { get; set; }
+        public string BranchName { get; set; }
         
         [Option('d', "date-filter", HelpText = "Get commits on or after this date. Defaults to no filter.")]
         public DateTime? DateFilter { get; set; }

--- a/src/gitnstats/gitnstats.csproj
+++ b/src/gitnstats/gitnstats.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
     <PublishTrimmed>true</PublishTrimmed>
     <RuntimeIdentifiers>osx-x64;linux-x64;win10-x64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
There's a bug in the commandline parser library that triggers when an option class has a custom usage function
and that function has more than one attribute.
When a class has nullable reference type properties, it's members are all tagged with the System.Runtime.CompilerServices.NullableAttribute attribute.
Disabling NRTs in just the Options.cs file fixes the bug while still allowing us to use NRTs elsewhere.

A bug has been submitted upstream
https://github.com/commandlineparser/commandline/issues/714

As well as a pull request that fixes the issue
https://github.com/commandlineparser/commandline/pull/715

The compiler directive can be removed once it's accepted and released.